### PR TITLE
Add interpolation rule / test

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -158,8 +158,12 @@ MultiLineCommentNoLineTerminator
 SingleLineComment
   = "//" (!LineTerminator SourceCharacter)*
 
+Interpolation
+  = "{{" __ name:IdentifierName __ "}}" { return name; }
+
 Identifier
   = !ReservedWord name:IdentifierName { return name; }
+  / Interpolation
 
 IdentifierName "identifier"
   = head:IdentifierStart tail:IdentifierPart* {

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -348,3 +348,8 @@ contract TypeIndexSpacing {
   uint [ 7 ] x;
   uint  []  y;
 }
+
+contract GnosisInterpolations {
+    uint constant x = 2;
+    EventFactory constant eventFactory = EventFactory({{EventFactory}});
+}


### PR DESCRIPTION
Allows SP to handle statements like:
```
EventFactory constant eventFactory = EventFactory({{EventFactory}});
```
without complaint.
