### PR TITLE
Add rules for newer assembly features & assembly assignment fix

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -1164,7 +1164,15 @@ function peg$parse(input, options) {
             end: location().end.offset
           }
         },
-      peg$c441 = function() {
+      peg$c441 = "case",
+      peg$c442 = peg$literalExpectation("case", false),
+      peg$c443 = "switch",
+      peg$c444 = peg$literalExpectation("switch", false),
+      peg$c445 = "default",
+      peg$c446 = peg$literalExpectation("default", false),
+      peg$c447 = "->",
+      peg$c448 = peg$literalExpectation("->", false),
+      peg$c449 = function() {
           return {
             type: "Identifier",
             name: "return",
@@ -1172,7 +1180,7 @@ function peg$parse(input, options) {
             end: location().end.offset
           }
         },
-      peg$c442 = function(name, head, tail) {
+      peg$c450 = function(name, head, tail) {
           return {
             type: "FunctionalAssemblyInstruction",
             name: name,
@@ -14171,18 +14179,35 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$parseAssemblyAssignment();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseNumericLiteral();
+            s0 = peg$parseAssemblySwitch();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseStringLiteral();
+              s0 = peg$parseAssemblyFunctionDefinition();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseHexStringLiteral();
+                s0 = peg$parseAssemblyFor();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseIdentifier();
+                  s0 = peg$parseAssemblyLiteral();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseIdentifier();
+                  }
                 }
               }
             }
           }
         }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssemblyLiteral() {
+    var s0;
+
+    s0 = peg$parseNumericLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseStringLiteral();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseHexStringLiteral();
       }
     }
 
@@ -14297,7 +14322,7 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseFunctionalAssemblyInstruction();
+            s5 = peg$parseAssemblyExpression();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
               s1 = peg$c437(s1, s5);
@@ -14356,6 +14381,437 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseAssemblyIdentifierList() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIdentifier();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 44) {
+        s4 = peg$c246;
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      }
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseIdentifier();
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s4 = peg$c246;
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseIdentifier();
+          if (s5 !== peg$FAILED) {
+            s4 = [s4, s5];
+            s3 = s4;
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssemblyCase() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parse__();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 4) === peg$c441) {
+        s2 = peg$c441;
+        peg$currPos += 4;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c442); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseAssemblyLiteral();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 58) {
+                s6 = peg$c282;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c283); }
+              }
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseInlineAssemblyBlock();
+                if (s7 !== peg$FAILED) {
+                  s1 = [s1, s2, s3, s4, s5, s6, s7];
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssemblySwitch() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
+
+    s0 = peg$currPos;
+    s1 = peg$parse__();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 6) === peg$c443) {
+        s2 = peg$c443;
+        peg$currPos += 6;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseAssemblyExpression();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
+              s6 = [];
+              s7 = peg$parseAssemblyCase();
+              while (s7 !== peg$FAILED) {
+                s6.push(s7);
+                s7 = peg$parseAssemblyCase();
+              }
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parse__();
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$currPos;
+                  if (input.substr(peg$currPos, 7) === peg$c445) {
+                    s9 = peg$c445;
+                    peg$currPos += 7;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c446); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 58) {
+                      s10 = peg$c282;
+                      peg$currPos++;
+                    } else {
+                      s10 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                    }
+                    if (s10 !== peg$FAILED) {
+                      s11 = peg$parseInlineAssemblyBlock();
+                      if (s11 !== peg$FAILED) {
+                        s9 = [s9, s10, s11];
+                        s8 = s9;
+                      } else {
+                        peg$currPos = s8;
+                        s8 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s8;
+                      s8 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s8;
+                    s8 = peg$FAILED;
+                  }
+                  if (s8 === peg$FAILED) {
+                    s8 = null;
+                  }
+                  if (s8 !== peg$FAILED) {
+                    s1 = [s1, s2, s3, s4, s5, s6, s7, s8];
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssemblyFunctionDefinition() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c168) {
+      s1 = peg$c168;
+      peg$currPos += 8;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseIdentifier();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 40) {
+              s5 = peg$c249;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c250); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseAssemblyIdentifierList();
+              if (s6 === peg$FAILED) {
+                s6 = null;
+              }
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c251;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c252); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse__();
+                  if (s8 !== peg$FAILED) {
+                    s9 = peg$currPos;
+                    if (input.substr(peg$currPos, 2) === peg$c447) {
+                      s10 = peg$c447;
+                      peg$currPos += 2;
+                    } else {
+                      s10 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+                    }
+                    if (s10 !== peg$FAILED) {
+                      s11 = peg$parseAssemblyIdentifierList();
+                      if (s11 !== peg$FAILED) {
+                        s10 = [s10, s11];
+                        s9 = s10;
+                      } else {
+                        peg$currPos = s9;
+                        s9 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
+                    }
+                    if (s9 === peg$FAILED) {
+                      s9 = null;
+                    }
+                    if (s9 !== peg$FAILED) {
+                      s10 = peg$parse__();
+                      if (s10 !== peg$FAILED) {
+                        s11 = peg$parseInlineAssemblyBlock();
+                        if (s11 !== peg$FAILED) {
+                          s1 = [s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11];
+                          s0 = s1;
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssemblyFor() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c164) {
+      s1 = peg$c164;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseInlineAssemblyBlock();
+        if (s3 === peg$FAILED) {
+          s3 = peg$parseAssemblyExpression();
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseAssemblyExpression();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseInlineAssemblyBlock();
+                if (s7 === peg$FAILED) {
+                  s7 = peg$parseAssemblyExpression();
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse__();
+                  if (s8 !== peg$FAILED) {
+                    s9 = peg$parseInlineAssemblyBlock();
+                    if (s9 !== peg$FAILED) {
+                      s1 = [s1, s2, s3, s4, s5, s6, s7, s8, s9];
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseReturnOpCode() {
     var s0, s1;
 
@@ -14369,7 +14825,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c441();
+      s1 = peg$c449();
     }
     s0 = s1;
 
@@ -14474,7 +14930,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c442(s1, s5, s7);
+                      s1 = peg$c450(s1, s5, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;

--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1581,10 +1581,16 @@ AssemblyItem
   / InlineAssemblyBlock
   / AssemblyLocalBinding
   / AssemblyAssignment
-  / NumericLiteral
+  / AssemblySwitch
+  / AssemblyFunctionDefinition
+  / AssemblyFor
+  / AssemblyLiteral
+  / Identifier
+
+AssemblyLiteral
+  = NumericLiteral
   / StringLiteral
   / HexStringLiteral
-  / Identifier
 
 AssemblyExpression
   = FunctionalAssemblyInstruction
@@ -1607,7 +1613,7 @@ AssemblyLocalBinding
   }
 
 AssemblyAssignment
-  = name:Identifier __ ':=' __ expression:FunctionalAssemblyInstruction {
+  = name:Identifier __ ':=' __ expression:AssemblyExpression {
     return {
       type: "AssemblyAssignment",
       name: name,
@@ -1624,6 +1630,23 @@ AssemblyAssignment
       end: location().end.offset
     }
   }
+
+AssemblyIdentifierList
+  = Identifier ( ',' Identifier )* 
+
+AssemblyCase
+  = __ 'case' __ AssemblyLiteral __ ':' InlineAssemblyBlock 
+
+AssemblySwitch
+  = __ 'switch' __ AssemblyExpression __ AssemblyCase* __ ( 'default' ':' InlineAssemblyBlock )? 
+
+
+AssemblyFunctionDefinition
+  = 'function' __ Identifier __ '(' AssemblyIdentifierList? ')' __ ( '->'  AssemblyIdentifierList )? __ InlineAssemblyBlock
+
+AssemblyFor
+  = 'for' __ ( InlineAssemblyBlock / AssemblyExpression ) 
+     __ AssemblyExpression __ ( InlineAssemblyBlock / AssemblyExpression ) __ InlineAssemblyBlock
 
 ReturnOpCode 
   = 'return' {

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -442,3 +442,85 @@ contract tupleAssignmentToMemberExpression {
     //(,vote.voted[msg.sender]) = isYay ? (0,1) : (0,2);
   }
 }
+
+library Array256Lib {
+  function sumElements(uint256[] storage self) constant returns(uint256 sum) {
+    assembly {
+      mstore(0x60,self_slot)
+
+      for { let i := 0 } lt(i, sload(self_slot)) { i := add(i, 1) } {
+        sum := add(sload(add(sha3(0x60,0x20),i)),sum)
+      }
+    }
+  }
+
+  function getMax(uint256[] storage self) constant returns(uint256 maxValue) {
+    assembly {
+      mstore(0x60,self_slot)
+      maxValue := sload(sha3(0x60,0x20))
+
+      for { let i := 0 } lt(i, sload(self_slot)) { i := add(i, 1) } {
+        switch gt(sload(add(sha3(0x60,0x20),i)), maxValue)
+        case 1 {
+          maxValue := sload(add(sha3(0x60,0x20),i))
+        }
+      }
+    }
+  }
+
+  function getMin(uint256[] storage self) constant returns(uint256 minValue) {
+    assembly {
+      mstore(0x60,self_slot)
+      minValue := sload(sha3(0x60,0x20))
+
+      for { let i := 0 } lt(i, sload(self_slot)) { i := add(i, 1) } {
+        switch gt(sload(add(sha3(0x60,0x20),i)), minValue)
+        case 0 {
+          minValue := sload(add(sha3(0x60,0x20),i))
+        }
+      }
+    }
+  }
+
+  function indexOf(uint256[] storage self, uint256 value, bool isSorted) constant
+           returns(bool found, uint256 index) {
+    assembly{
+      mstore(0x60,self_slot)
+      switch isSorted
+      case 1 {
+        let high := sub(sload(self_slot),1)
+        let mid := 0
+        let low := 0
+        for { } iszero(gt(low, high)) { } {
+          mid := div(add(low,high),2)
+
+          switch lt(sload(add(sha3(0x60,0x20),mid)),value)
+          case 1 {
+             low := add(mid,1)
+          }
+          case 0 {
+            switch gt(sload(add(sha3(0x60,0x20),mid)),value)
+            case 1 {
+              high := sub(mid,1)
+            }
+            case 0 {
+              found := 1
+              index := mid
+              low := add(high,1)
+            }
+          }
+        }
+      }
+      case 0 {
+        for { let low := 0 } lt(low, sload(self_slot)) { low := add(low, 1) } {
+          switch eq(sload(add(sha3(0x60,0x20),low)), value)
+          case 1 {
+            found := 1
+            index := low
+            low := sload(self_slot)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
+ Adds @duaraghav8 's fix for assembly assignments @ solparse [here](https://github.com/duaraghav8/solparse/commit/4b3c6e291928f72caaa549557c051943000a587a) - also open as an SP issue [here](https://github.com/ConsenSys/solidity-parser/issues/91)
+ Adds skeletal rules for assembly `for`, `switch` and `function` statements. No AST work was done for these since we don't instrument assembly. Just trying to parse without crashing here.  