### PR TITLE
Stop using wrong future reserved keywords

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -2029,12 +2029,9 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyword();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseFutureReservedWord();
+      s0 = peg$parseNullToken();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseNullToken();
-        if (s0 === peg$FAILED) {
-          s0 = peg$parseBooleanLiteral();
-        }
+        s0 = peg$parseBooleanLiteral();
       }
     }
 

--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -203,7 +203,6 @@ UnicodeConnectorPunctuation
 
 ReservedWord
   = Keyword
-  / FutureReservedWord
   / NullToken
   / BooleanLiteral
 

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -461,6 +461,10 @@ contract functionThatReceivesAFunction {
   function fn(function() internal pure returns(bool) p);
 }
 
+contract usesFutureReservedWork {
+  uint class;
+}
+
 library Array256Lib {
   function sumElements(uint256[] storage self) constant returns(uint256 sum) {
     assembly {


### PR DESCRIPTION
Like `class`.